### PR TITLE
Ensure returned url is escaped prior to display.

### DIFF
--- a/busted.php
+++ b/busted.php
@@ -95,7 +95,7 @@ class Storm_Busted {
 
 		}
 
-		return $uri;
+		return esc_url( $uri );
 
 	}
 


### PR DESCRIPTION
Due to the potential for add_query_arg to enable XSS, add the `esc_url` to the return to ensure the URI is properly escaped.
